### PR TITLE
dont pull usage data for customers without a reseller relationship

### DIFF
--- a/AzureBillingAnalytics/BillingDataApi/Controllers/CspUsageController.cs
+++ b/AzureBillingAnalytics/BillingDataApi/Controllers/CspUsageController.cs
@@ -48,7 +48,7 @@ namespace BillingDataApi.Controllers
             {
                 try
                 {
-                    if(customer.RelationshipToPartner.ToString() != "Reseller")
+                    if(customer.RelationshipToPartner != CustomerPartnerRelationship.Reseller)
                     {
                         continue;
                     }

--- a/AzureBillingAnalytics/BillingDataApi/Controllers/CspUsageController.cs
+++ b/AzureBillingAnalytics/BillingDataApi/Controllers/CspUsageController.cs
@@ -48,6 +48,10 @@ namespace BillingDataApi.Controllers
             {
                 try
                 {
+                    if(customer.RelationshipToPartner.ToString() != "Reseller")
+                    {
+                        continue;
+                    }
                     var subscriptionsPage = partnerOperations.Customers.ById(customer.Id).Subscriptions.Get();
 
                     List<Microsoft.Store.PartnerCenter.Models.Subscriptions.Subscription> currentSubscriptions =


### PR DESCRIPTION
Stops the CSPUsage API from throwing an exception with the following message:
Reseller CAID XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX does not have a reseller relationship with customer CAID XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX.

